### PR TITLE
#Feat: Kahlua admin

### DIFF
--- a/homepage/src/app/components/kahlua_admin/ApplicationList.tsx
+++ b/homepage/src/app/components/kahlua_admin/ApplicationList.tsx
@@ -33,6 +33,7 @@ const AppList: React.FC<AppListProps> = ({session}) => {
   const [applications, setApplications] = useState<Application[]>([]);
   const [loading, setLoading] = useState(false);
   const [count, setCount] = useState();
+  const [name_sorted, setNameSorted] = useState(false);
   
   useEffect(() => {
 
@@ -40,8 +41,9 @@ const AppList: React.FC<AppListProps> = ({session}) => {
       setLoading(true);
       try {
         const query = session === "전체" ? "" : `?first_preference=${session}`;
+        const sorting = name_sorted ? `?name=${name_sorted}` : ""
         const response = await authAxios.get(
-          `https://api.kahluaband.com/kahlua_admin/application/apply_forms${query}`
+          `https://api.kahluaband.com/kahlua_admin/application/apply_forms${sorting}${query}`
           // query params에서 first_preference를 각 세션으로 설정해서 해당 세션을 1지망으로 선택한 지원서 디비를 받아옴
         );
         setApplications(response.data.data.apply_forms);
@@ -52,7 +54,7 @@ const AppList: React.FC<AppListProps> = ({session}) => {
       setLoading(false);
     };
     fetchData();
-  }, [session]);
+  }, [session, name_sorted]);
 
   if (loading) {
     return <div>대기 중 ...</div>;
@@ -79,8 +81,8 @@ const AppList: React.FC<AppListProps> = ({session}) => {
           </div>
 
           <li className="flex flex-row h-16 w-[2692px] bg-[#D9D9D9] px-4 items-center text-center">
-            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
-              이름
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2" onClick={()=>setNameSorted(!name_sorted)}>
+              이름 {name_sorted ? "∨" : "∧"}
             </p>
             <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               성별

--- a/homepage/src/app/components/kahlua_admin/ParticipantItem_general.tsx
+++ b/homepage/src/app/components/kahlua_admin/ParticipantItem_general.tsx
@@ -4,7 +4,8 @@ const ParticipantItem: React.FC<{ participant: any }> = ({participant}) => {
     return(
         <li className="flex flex-row h-16 w-[1380px] px-4 items-center text-center">
             <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                {name}
+                {name}<br/>
+                {phone_num}
             </p>
             <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
                 {phone_num}

--- a/homepage/src/app/components/kahlua_admin/ParticipantItem_general.tsx
+++ b/homepage/src/app/components/kahlua_admin/ParticipantItem_general.tsx
@@ -1,16 +1,11 @@
 const ParticipantItem: React.FC<{ participant: any }> = ({participant}) => {
-    const {id, name, phone_num} = participant;
+    const {name, phone_num} = participant;
 
     return(
-        <li className="flex flex-row h-16 w-[1380px] px-4 items-center text-center">
-            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                {name}<br/>
-                {phone_num}
-            </p>
-            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                {phone_num}
-            </p>
-        </li>
+        <p className="flex justify-center items-center w-[140px] h-full text-sm p-2">
+            {name}<br/>
+            {phone_num}
+        </p>
     )
 }
 

--- a/homepage/src/app/components/kahlua_admin/ParticipantItem_general.tsx
+++ b/homepage/src/app/components/kahlua_admin/ParticipantItem_general.tsx
@@ -1,0 +1,16 @@
+const ParticipantItem: React.FC<{ participant: any }> = ({participant}) => {
+    const {id, name, phone_num} = participant;
+
+    return(
+        <li className="flex flex-row h-16 w-[1380px] px-4 items-center text-center">
+            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                {name}
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                {phone_num}
+            </p>
+        </li>
+    )
+}
+
+export default ParticipantItem;

--- a/homepage/src/app/components/kahlua_admin/TicketItem_all.tsx
+++ b/homepage/src/app/components/kahlua_admin/TicketItem_all.tsx
@@ -1,5 +1,7 @@
+import ParticipantItem from "./ParticipantItem_general";
+
 const AllTicketItem: React.FC<{ ticket: any }> = ({ticket}) => {
-    const {id, buyer, phone_num, count, member, major, student_id, meeting, reservation_id, merchant_order_id, status} = ticket;
+    const {id, buyer, phone_num, count, member, major, student_id, meeting, reservation_id, merchant_order_id, status, participants} = ticket;
     let statusText
     if (status === true) {
         statusText = "결제완료"
@@ -9,7 +11,7 @@ const AllTicketItem: React.FC<{ ticket: any }> = ({ticket}) => {
     }
 
     return(
-        <li className="flex flex-row h-16 w-[1380px] px-4 items-center text-center">
+        <li className="flex flex-row h-16 w-[1476px] px-4 items-center text-center">
             <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
                 {reservation_id}
                 {merchant_order_id}
@@ -38,6 +40,10 @@ const AllTicketItem: React.FC<{ ticket: any }> = ({ticket}) => {
                     {statusText}
                 </p>
             </div>
+
+            {participants && participants.map((participant: any) => (
+                <ParticipantItem key={participant.name} participant={participant} />
+            ))}
         </li>
     )
 }

--- a/homepage/src/app/components/kahlua_admin/TicketItem_all.tsx
+++ b/homepage/src/app/components/kahlua_admin/TicketItem_all.tsx
@@ -1,6 +1,13 @@
 const AllTicketItem: React.FC<{ ticket: any }> = ({ticket}) => {
-    const {id, buyer, phone_num, count, member, major, student_id, meeting, reservation_id, merchant_order_id, transaction_status} = ticket;
-    
+    const {id, buyer, phone_num, count, member, major, student_id, meeting, reservation_id, merchant_order_id, status} = ticket;
+    let statusText
+    if (status === true) {
+        statusText = "결제완료"
+    }
+    if (status === false) {
+        statusText = "결제대기"
+    }
+
     return(
         <li className="flex flex-row h-16 w-[1380px] px-4 items-center text-center">
             <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
@@ -26,9 +33,11 @@ const AllTicketItem: React.FC<{ ticket: any }> = ({ticket}) => {
             <p className="flex justify-center items-center w-[120px] h-full text-sm p-2">
                 {meeting}
             </p>
-            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                {transaction_status}
-            </p>
+            <div className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                <p className={`${status ? "text-black" : "text-red-500"}`}>
+                    {statusText}
+                </p>
+            </div>
         </li>
     )
 }

--- a/homepage/src/app/components/kahlua_admin/TicketItem_general.tsx
+++ b/homepage/src/app/components/kahlua_admin/TicketItem_general.tsx
@@ -1,30 +1,67 @@
-const GeneralTicketItem: React.FC<{ ticket: any }> = ({ticket}) => {
+import ParticipantItem from "./ParticipantItem_general";
+
+const GeneralTicketItem: React.FC<{ ticket: any, participants: any[] }> = ({ticket, participants}) => {
     const {id, buyer, phone_num, count, member, major, student_id, meeting, reservation_id, merchant_order_id, status} = ticket;
     let statusText = status ? "결제완료" : "결제대기";
 
-    return(
-        <li className="flex flex-row h-16 w-[1380px] px-4 items-center text-center">
-            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                {reservation_id}
-                {merchant_order_id}
-            </p>
-            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                {buyer}
-            </p>
-            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                {phone_num}
-            </p>
-            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                {count}
-                {member}
-            </p>
-            <div className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                <p className={`${status ? "text-black" : "text-red-500"}`}>
-                    {statusText}
+    if (!participants){
+        return(
+            <li className="flex flex-row h-16 w-[1380px] px-4 items-center text-center">
+                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                    {reservation_id}
+                    {merchant_order_id}
                 </p>
-            </div>
-        </li>
-    )
+                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                    {buyer}
+                </p>
+                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                    {phone_num}
+                </p>
+                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                    {count}
+                    {member}
+                </p>
+                <div className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                    <p className={`${status ? "text-black" : "text-red-500"}`}>
+                        {statusText}
+                    </p>
+                </div>
+            </li>
+        )
+    }
+
+    if (participants){
+        return(
+            <li className="flex flex-row h-16 w-[1380px] px-4 items-center text-center">
+                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                    {reservation_id}
+                    {merchant_order_id}
+                </p>
+                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                    {buyer}
+                </p>
+                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                    {phone_num}
+                </p>
+                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                    {count}
+                    {member}
+                </p>
+                <div className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                    <p className={`${status ? "text-black" : "text-red-500"}`}>
+                        {statusText}
+                    </p>
+                </div>
+    
+                <>
+                    {participants.map((participant) => (
+                        <ParticipantItem key={participant.id} participant={participant}/>
+                    ))}
+                </>
+            </li>
+        )
+    }
+
 }
 
 export default GeneralTicketItem;

--- a/homepage/src/app/components/kahlua_admin/TicketItem_general.tsx
+++ b/homepage/src/app/components/kahlua_admin/TicketItem_general.tsx
@@ -1,66 +1,36 @@
 import ParticipantItem from "./ParticipantItem_general";
 
-const GeneralTicketItem: React.FC<{ ticket: any, participants: any[] }> = ({ticket, participants}) => {
-    const {id, buyer, phone_num, count, member, major, student_id, meeting, reservation_id, merchant_order_id, status} = ticket;
+const GeneralTicketItem: React.FC<{ ticket: any }> = ({ticket}) => {
+    const {id, buyer, phone_num, count, member, major, student_id, meeting, reservation_id, merchant_order_id, status, participants} = ticket;
     let statusText = status ? "결제완료" : "결제대기";
 
-    if (!participants){
-        return(
-            <li className="flex flex-row h-16 w-[1380px] px-4 items-center text-center">
-                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                    {reservation_id}
-                    {merchant_order_id}
+    return(
+        <li className="flex flex-row h-16 w-[1380px] px-4 items-center text-center">
+            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                {reservation_id}
+                {merchant_order_id}
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                {buyer}
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                {phone_num}
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                {count}
+                {member}
+            </p>
+            <div className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                <p className={`${status ? "text-black" : "text-red-500"}`}>
+                    {statusText}
                 </p>
-                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                    {buyer}
-                </p>
-                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                    {phone_num}
-                </p>
-                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                    {count}
-                    {member}
-                </p>
-                <div className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                    <p className={`${status ? "text-black" : "text-red-500"}`}>
-                        {statusText}
-                    </p>
-                </div>
-            </li>
-        )
-    }
+            </div>
 
-    if (participants){
-        return(
-            <li className="flex flex-row h-16 w-[1380px] px-4 items-center text-center">
-                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                    {reservation_id}
-                    {merchant_order_id}
-                </p>
-                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                    {buyer}
-                </p>
-                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                    {phone_num}
-                </p>
-                <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                    {count}
-                    {member}
-                </p>
-                <div className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                    <p className={`${status ? "text-black" : "text-red-500"}`}>
-                        {statusText}
-                    </p>
-                </div>
-    
-                <>
-                    {participants.map((participant) => (
-                        <ParticipantItem key={participant.id} participant={participant}/>
-                    ))}
-                </>
-            </li>
-        )
-    }
+            {participants && participants.map((participant: any) => (
+                <ParticipantItem key={participant.name} participant={participant} />
+            ))}
+        </li>
+    )
 
 }
 

--- a/homepage/src/app/components/kahlua_admin/TicketItem_general.tsx
+++ b/homepage/src/app/components/kahlua_admin/TicketItem_general.tsx
@@ -1,6 +1,7 @@
 const GeneralTicketItem: React.FC<{ ticket: any }> = ({ticket}) => {
-    const {id, buyer, phone_num, count, member, major, student_id, meeting, reservation_id, merchant_order_id, transaction_status} = ticket;
-    
+    const {id, buyer, phone_num, count, member, major, student_id, meeting, reservation_id, merchant_order_id, status} = ticket;
+    let statusText = status ? "결제완료" : "결제대기";
+
     return(
         <li className="flex flex-row h-16 w-[1380px] px-4 items-center text-center">
             <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
@@ -17,9 +18,11 @@ const GeneralTicketItem: React.FC<{ ticket: any }> = ({ticket}) => {
                 {count}
                 {member}
             </p>
-            <p className="flex justify-center items-center w-[100px] h-full text-sm p-2">
-                {transaction_status}
-            </p>
+            <div className="flex justify-center items-center w-[100px] h-full text-sm p-2">
+                <p className={`${status ? "text-black" : "text-red-500"}`}>
+                    {statusText}
+                </p>
+            </div>
         </li>
     )
 }

--- a/homepage/src/app/components/kahlua_admin/TicketList_all.tsx
+++ b/homepage/src/app/components/kahlua_admin/TicketList_all.tsx
@@ -51,7 +51,7 @@ const AllTicketList = () => {
             </p>
           </div>
 
-          <li className="flex flex-row h-16 w-[1380px] bg-[#D9D9D9] px-4 items-center text-center">
+          <li className="flex flex-row h-16 w-[1476px] bg-[#D9D9D9] px-4 items-center text-center">
             <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               예매번호
             </p>
@@ -75,6 +75,18 @@ const AllTicketList = () => {
             </p>
             <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               결제상황
+            </p>
+            <p className="flex justify-center items-center w-[140px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+              참석자 1
+            </p>
+            <p className="flex justify-center items-center w-[140px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+              참석자 2
+            </p>
+            <p className="flex justify-center items-center w-[140px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+              참석자 3
+            </p>
+            <p className="flex justify-center items-center w-[140px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+              참석자 4
             </p>
           </li>
 

--- a/homepage/src/app/components/kahlua_admin/TicketList_all.tsx
+++ b/homepage/src/app/components/kahlua_admin/TicketList_all.tsx
@@ -9,14 +9,16 @@ const AllTicketList = () => {
   const [tickets, setTickets] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
   const [count, setCount] = useState();
-  
+  const [name_sorted, setNameSorted] = useState(false);
+
   useEffect(() => {
 
     const fetchData = async () => {
       setLoading(true);
       try {
+        const sorting = name_sorted ? "" : `?name=${name_sorted}`
         const response = await authAxios.get(
-          `https://api.kahluaband.com/kahlua_admin/tickets/all/`
+          `https://api.kahluaband.com/kahlua_admin/tickets/all/${sorting}`
         );
         setTickets(response.data.data.tickets);
         setCount(response.data.data.total_tickets);
@@ -26,7 +28,7 @@ const AllTicketList = () => {
       setLoading(false);
     };
     fetchData();
-  }, []);
+  }, [name_sorted]);
 
   if (loading) {
     return <div>대기 중 ...</div>;
@@ -53,8 +55,8 @@ const AllTicketList = () => {
             <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               예매번호
             </p>
-            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
-              이름
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2" onClick={()=>setNameSorted(!name_sorted)}>
+              이름 {name_sorted ? "∧" : "∨"}
             </p>
             <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               전화번호

--- a/homepage/src/app/components/kahlua_admin/TicketList_freshman.tsx
+++ b/homepage/src/app/components/kahlua_admin/TicketList_freshman.tsx
@@ -9,14 +9,16 @@ const FreshmanTicketList = () => {
   const [tickets, setTickets] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
   const [count, setCount] = useState();
+  const [name_sorted, setNameSorted] = useState(false);
   
   useEffect(() => {
 
     const fetchData = async () => {
       setLoading(true);
       try {
+        const sorting = name_sorted ? `?name=${name_sorted}` : ""
         const response = await authAxios.get(
-          `https://api.kahluaband.com/kahlua_admin/tickets/freshman_tickets/`
+          `https://api.kahluaband.com/kahlua_admin/tickets/freshman_tickets/${sorting}`
         );
         setTickets(response.data.data.tickets);
         setCount(response.data.data.total_freshman);
@@ -26,7 +28,7 @@ const FreshmanTicketList = () => {
       setLoading(false);
     };
     fetchData();
-  }, []);
+  }, [name_sorted]);
 
   if (loading) {
     return <div>대기 중 ...</div>;
@@ -53,8 +55,8 @@ const FreshmanTicketList = () => {
             <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               예매번호
             </li>
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
-              이름
+            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2" onClick={()=>setNameSorted(!name_sorted)}>
+              이름 {name_sorted ? "∧" : "∨"}
             </li>
             <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               전화번호
@@ -75,7 +77,7 @@ const FreshmanTicketList = () => {
 
           <>
             {tickets.map((ticket) => (
-              <FreshmanTicketItem key={ticket.id} ticket={ticket} />
+              <FreshmanTicketItem key={ticket.id} ticket={ticket}/>
             ))}
           </>
         </>

--- a/homepage/src/app/components/kahlua_admin/TicketList_freshman.tsx
+++ b/homepage/src/app/components/kahlua_admin/TicketList_freshman.tsx
@@ -52,27 +52,27 @@ const FreshmanTicketList = () => {
           </div>
 
           <div className="flex flex-row h-16 w-[1380px] bg-[#D9D9D9] px-4 items-center text-center">
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               예매번호
-            </li>
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2" onClick={()=>setNameSorted(!name_sorted)}>
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2" onClick={()=>setNameSorted(!name_sorted)}>
               이름 {name_sorted ? "∧" : "∨"}
-            </li>
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               전화번호
-            </li>
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               매수
-            </li>
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               학과
-            </li>
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               학번
-            </li>
-            <li className="flex justify-center items-center w-[120px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+            </p>
+            <p className="flex justify-center items-center w-[120px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               뒷풀이 참석 여부
-            </li>
+            </p>
           </div>
 
           <>

--- a/homepage/src/app/components/kahlua_admin/TicketList_general.tsx
+++ b/homepage/src/app/components/kahlua_admin/TicketList_general.tsx
@@ -2,13 +2,11 @@ import React from "react";
 import { useState, useEffect } from "react";
 import { getAuthAxios } from "@/apis/authAxios";
 import GeneralTicketItem from "./TicketItem_general";
-import ParticipantItem from "./ParticipantItem_general";
 
 const GeneralTicketList = () => {
   const access = localStorage.getItem("access");
   const authAxios = getAuthAxios(access);
   const [tickets, setTickets] = useState<any[]>([]);
-  const [participants, setParticipants] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
   const [count, setCount] = useState();
   const [name_sorted, setNameSorted] = useState(false);
@@ -23,8 +21,6 @@ const GeneralTicketList = () => {
           `https://api.kahluaband.com/kahlua_admin/tickets/general_tickets/${sorting}`
         );
         setTickets(response.data.data.tickets);
-        setParticipants(response.data.data.tickets.participants);
-        console.log(participants);
         setCount(response.data.data.total_general);
       } catch (error) {
         console.log(error);
@@ -56,34 +52,39 @@ const GeneralTicketList = () => {
           </div>
 
           <div className="flex flex-row h-16 w-[1380px] bg-[#D9D9D9] px-4 items-center text-center">
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               예매번호
-            </li>
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2" onClick={()=>setNameSorted(!name_sorted)}>
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2" onClick={()=>setNameSorted(!name_sorted)}>
               이름 {name_sorted ? "∧" : "∨"}
-            </li>
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               전화번호
-            </li>
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               매수
-            </li>
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+            </p>
+            <p className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               결제상황
-            </li>
+            </p>
+            <p className="flex justify-center items-center w-[140px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+              참석자 1
+            </p>
+            <p className="flex justify-center items-center w-[140px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+              참석자 2
+            </p>
+            <p className="flex justify-center items-center w-[140px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+              참석자 3
+            </p>
+            <p className="flex justify-center items-center w-[140px] h-full bg-[#D9D9D9] text-base font-bold p-2">
+              참석자 4
+            </p>
           </div>
 
-          <>
-            {tickets.map((ticket) => (
-              <GeneralTicketItem key={ticket.id} ticket={ticket} participants={participants}/>
-            ))}
-          </>
+          {tickets.map((ticket) => (
+            <GeneralTicketItem key={ticket.id} ticket={ticket}/>
+          ))}
 
-          {/* <>
-            {participants.map((participant) => (
-              <ParticipantItem key={participant.id} participant={participant}/>
-            ))}
-          </> */}
         </>
       }
     </div>

--- a/homepage/src/app/components/kahlua_admin/TicketList_general.tsx
+++ b/homepage/src/app/components/kahlua_admin/TicketList_general.tsx
@@ -2,23 +2,29 @@ import React from "react";
 import { useState, useEffect } from "react";
 import { getAuthAxios } from "@/apis/authAxios";
 import GeneralTicketItem from "./TicketItem_general";
+import ParticipantItem from "./ParticipantItem_general";
 
 const GeneralTicketList = () => {
   const access = localStorage.getItem("access");
   const authAxios = getAuthAxios(access);
   const [tickets, setTickets] = useState<any[]>([]);
+  const [participants, setParticipants] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
   const [count, setCount] = useState();
+  const [name_sorted, setNameSorted] = useState(false);
 
   useEffect(() => {
 
     const fetchData = async () => {
       setLoading(true);
       try {
+        const sorting = name_sorted ? `?name=${name_sorted}` : ""
         const response = await authAxios.get(
-          `https://api.kahluaband.com/kahlua_admin/tickets/general_tickets/`
+          `https://api.kahluaband.com/kahlua_admin/tickets/general_tickets/${sorting}`
         );
         setTickets(response.data.data.tickets);
+        setParticipants(response.data.data.tickets.participants);
+        console.log(participants);
         setCount(response.data.data.total_general);
       } catch (error) {
         console.log(error);
@@ -26,7 +32,7 @@ const GeneralTicketList = () => {
       setLoading(false);
     };
     fetchData();
-  }, []);
+  }, [name_sorted]);
 
   if (loading) {
     return <div>대기 중 ...</div>;
@@ -53,8 +59,8 @@ const GeneralTicketList = () => {
             <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               예매번호
             </li>
-            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
-              이름
+            <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2" onClick={()=>setNameSorted(!name_sorted)}>
+              이름 {name_sorted ? "∧" : "∨"}
             </li>
             <li className="flex justify-center items-center w-[100px] h-full bg-[#D9D9D9] text-base font-bold p-2">
               전화번호
@@ -69,9 +75,15 @@ const GeneralTicketList = () => {
 
           <>
             {tickets.map((ticket) => (
-              <GeneralTicketItem key={ticket.id} ticket={ticket} />
+              <GeneralTicketItem key={ticket.id} ticket={ticket}/>
             ))}
           </>
+
+          {/* <>
+            {participants.map((participant) => (
+              <ParticipantItem key={participant.id} participant={participant}/>
+            ))}
+          </> */}
         </>
       }
     </div>

--- a/homepage/src/app/components/kahlua_admin/TicketList_general.tsx
+++ b/homepage/src/app/components/kahlua_admin/TicketList_general.tsx
@@ -75,7 +75,7 @@ const GeneralTicketList = () => {
 
           <>
             {tickets.map((ticket) => (
-              <GeneralTicketItem key={ticket.id} ticket={ticket}/>
+              <GeneralTicketItem key={ticket.id} ticket={ticket} participants={participants}/>
             ))}
           </>
 


### PR DESCRIPTION
1. 결제상황 반영
2. 이름순정렬 버튼
3. 일반예매 참석자 명단 추가

백엔드 TODO
1. tickets/all?name=true 이름순 정렬 기능 추가
2. application 세션별 지원자 카운트

경고메세지
tickets/all -> 신입생/일반티켓의 id값이 중복돼서 key값 중복 경고